### PR TITLE
feature/6190-historico

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -88,6 +88,7 @@ THIRD_PARTY_APPS = [
     "rest_framework_swagger",
     "django_prometheus",
     "des",
+    "auditlog",
 ]
 
 LOCAL_APPS = [
@@ -132,6 +133,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
+    "auditlog.middleware.AuditlogMiddleware",
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#password-hashers
 PASSWORD_HASHERS = [

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,3 +41,9 @@ django-admin-interface==0.11.1
 
 # Pandas - Para importação de dados
 pandas==0.25.1
+
+# Para gravação de log de alterações nos modelos
+# https://django-auditlog.readthedocs.io/en/latest/index.html
+#django-auditlog==0.4.5
+# Pegando última versão diretamente do repositório oficial.
+-e git:https://github.com/jjkester/django-auditlog.git

--- a/sme_coad_apps/contratos/models/contrato.py
+++ b/sme_coad_apps/contratos/models/contrato.py
@@ -1,5 +1,7 @@
 import datetime
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
 from dateutil.relativedelta import relativedelta
 from django.db import models
 
@@ -11,6 +13,8 @@ from ...users.models import User
 
 
 class Contrato(ModeloBase):
+    historico = AuditlogHistoryField()
+
     # Estado do Contrato
     ESTADO_EMERGENCIAL = 'EMERGENCIAL'
     ESTADO_EXCEPCIONAL = 'EXCEPCIONAL'
@@ -92,6 +96,8 @@ class Contrato(ModeloBase):
 
 
 class ContratoUnidade(ModeloBase):
+    historico = AuditlogHistoryField()
+
     contrato = models.ForeignKey(Contrato, on_delete=models.CASCADE, related_name="unidades")
     unidade = models.ForeignKey(Unidade, on_delete=models.PROTECT, related_name="contratos", to_field="codigo_eol")
     valor_mensal = models.DecimalField(max_digits=9, decimal_places=2, default=0.00)
@@ -113,3 +119,7 @@ class ContratoUnidade(ModeloBase):
     class Meta:
         verbose_name = 'Unidade de Contrato'
         verbose_name_plural = 'Unidades de Contratos'
+
+
+auditlog.register(Contrato)
+auditlog.register(ContratoUnidade)

--- a/sme_coad_apps/contratos/models/empresa.py
+++ b/sme_coad_apps/contratos/models/empresa.py
@@ -1,3 +1,5 @@
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
 from brazilnum.cnpj import format_cnpj
 from django.core.validators import MinLengthValidator
 from django.db import models
@@ -6,8 +8,9 @@ from ...core.models_abstracts import ModeloBase, TemNome
 
 
 class Empresa(ModeloBase, TemNome):
-    # TODO Implementar validação do CNPJ para não permitir gravação de CNPJ inválido.
+    historico = AuditlogHistoryField()
 
+    # TODO Implementar validação do CNPJ para não permitir gravação de CNPJ inválido.
     cnpj = models.CharField('CNPJ', validators=[MinLengthValidator(14)], max_length=14, unique=True)
 
     def __str__(self):
@@ -20,3 +23,6 @@ class Empresa(ModeloBase, TemNome):
     class Meta:
         verbose_name = 'Empresa Contratada'
         verbose_name_plural = 'Empresas Contratadas'
+
+
+auditlog.register(Empresa)

--- a/sme_coad_apps/contratos/models/tipo_servico.py
+++ b/sme_coad_apps/contratos/models/tipo_servico.py
@@ -1,9 +1,13 @@
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
 from django.db import models
 
 from ...core.models_abstracts import ModeloBase
 
 
 class TipoServico(ModeloBase):
+    historico = AuditlogHistoryField()
+
     nome = models.CharField('Nome', max_length=160, unique=True)
 
     def __str__(self):
@@ -12,3 +16,6 @@ class TipoServico(ModeloBase):
     class Meta:
         verbose_name = 'Tipo de Serviço'
         verbose_name_plural = 'Tipos de Serviço'
+
+
+auditlog.register(TipoServico)

--- a/sme_coad_apps/contratos/tests/test_model_contrato.py
+++ b/sme_coad_apps/contratos/tests/test_model_contrato.py
@@ -33,6 +33,7 @@ def test_instance_model():
     assert isinstance(model.gestor, User)
     assert isinstance(model.observacoes, str)
     assert isinstance(model.estado_contrato, str)
+    assert model.historico
 
 
 def test_srt_model():
@@ -79,6 +80,7 @@ def test_instance_model_detalhe():
     assert isinstance(model.valor_total, float)
     assert isinstance(model.dotacao_orcamentaria, str)
     assert isinstance(model.lote, str)
+    assert model.historico
 
 
 def test_srt_model_detalhe():

--- a/sme_coad_apps/contratos/tests/test_model_empresa.py
+++ b/sme_coad_apps/contratos/tests/test_model_empresa.py
@@ -13,6 +13,7 @@ def test_instance_model():
     assert isinstance(model, Empresa)
     assert isinstance(model.nome, str)
     assert isinstance(model.cnpj, str)
+    assert model.historico
 
 
 def test_srt_model():

--- a/sme_coad_apps/contratos/tests/test_model_tipo_servico.py
+++ b/sme_coad_apps/contratos/tests/test_model_tipo_servico.py
@@ -2,8 +2,8 @@ import pytest
 from django.contrib import admin
 from model_mommy import mommy
 
-from ..models import TipoServico
 from ..admin import TipoServicoAdmin
+from ..models import TipoServico
 
 pytestmark = pytest.mark.django_db
 
@@ -12,6 +12,7 @@ def test_instance_model():
     model = mommy.make('TipoServico', nome='Limpeza')
     assert isinstance(model, TipoServico)
     assert isinstance(model.nome, str)
+    assert model.historico
 
 
 def test_srt_model():

--- a/sme_coad_apps/core/models/divisao.py
+++ b/sme_coad_apps/core/models/divisao.py
@@ -1,9 +1,13 @@
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
 from django.db import models
 
 from ..models_abstracts import TemNome, ModeloBase
 
 
 class Divisao(ModeloBase, TemNome):
+    historico = AuditlogHistoryField()
+
     sigla = models.CharField('Sigla', max_length=15)
 
     def __str__(self):
@@ -12,3 +16,6 @@ class Divisao(ModeloBase, TemNome):
     class Meta:
         verbose_name = 'Divisão'
         verbose_name_plural = 'Divisões'
+
+
+auditlog.register(Divisao)

--- a/sme_coad_apps/core/models/nucleo.py
+++ b/sme_coad_apps/core/models/nucleo.py
@@ -1,10 +1,14 @@
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
 from django.db import models
 
-from ..models_abstracts import TemNome, ModeloBase
 from ..models import Divisao
+from ..models_abstracts import TemNome, ModeloBase
 
 
 class Nucleo(ModeloBase, TemNome):
+    historico = AuditlogHistoryField()
+
     sigla = models.CharField('Sigla', max_length=20)
     divisao = models.ForeignKey(Divisao, on_delete=models.PROTECT)
 
@@ -14,3 +18,6 @@ class Nucleo(ModeloBase, TemNome):
     class Meta:
         verbose_name = 'Núcleo'
         verbose_name_plural = 'Núcleos'
+
+
+auditlog.register(Nucleo)

--- a/sme_coad_apps/core/models/unidade.py
+++ b/sme_coad_apps/core/models/unidade.py
@@ -1,9 +1,13 @@
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
 from django.db import models
 
 from ..models_abstracts import TemNome, ModeloBase
 
 
 class Unidade(ModeloBase, TemNome):
+    historico = AuditlogHistoryField(pk_indexable=False)
+
     # Equipamentos Choice
     EQP_UNIDADE_ADMINISTRATIVA = 'UA'
     EQP_UNIDADE_ENSINO = 'UE'
@@ -49,3 +53,6 @@ class Unidade(ModeloBase, TemNome):
     class Meta:
         verbose_name = 'Unidade'
         verbose_name_plural = 'Unidades'
+
+
+auditlog.register(Unidade)

--- a/sme_coad_apps/core/tests/test_divisao_models.py
+++ b/sme_coad_apps/core/tests/test_divisao_models.py
@@ -13,6 +13,7 @@ def test_instance_model():
     assert isinstance(model, Divisao)
     assert isinstance(model.nome, str)
     assert isinstance(model.sigla, str)
+    assert model.historico
 
 
 def test_srt_model():

--- a/sme_coad_apps/core/tests/test_nucleo_model.py
+++ b/sme_coad_apps/core/tests/test_nucleo_model.py
@@ -14,6 +14,7 @@ def test_instance_model():
     assert isinstance(model.nome, str)
     assert isinstance(model.sigla, str)
     assert isinstance(model.divisao, Divisao)
+    assert model.historico
 
 
 def test_str_model():

--- a/sme_coad_apps/core/tests/test_unidade_models.py
+++ b/sme_coad_apps/core/tests/test_unidade_models.py
@@ -16,6 +16,7 @@ def test_instance_model():
     assert isinstance(model.tipo_unidade, str)
     assert isinstance(model.codigo_eol, str)
     assert isinstance(model.cep, str)
+    assert model.historico
 
 
 def test_srt_model():


### PR DESCRIPTION
Esse PR:

- Cria recurso de gravação de histórico de alterações da base de dados;

- Configura para gravação do histórico de alterações os modelos: Contrato, Empresa, Tipo de Serviço, Divisão, Núcleo e Unidade.

Com essa modificação, bastam poucas configurações para que o sistema
passe a registrar um log de alterações de um modelo.