### PR TITLE
feature/6422-api-historico

### DIFF
--- a/sme_coad_apps/core/api/serializers/historico_serializer.py
+++ b/sme_coad_apps/core/api/serializers/historico_serializer.py
@@ -1,0 +1,8 @@
+from auditlog.models import LogEntry
+from rest_framework import serializers
+
+
+class HistoricoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LogEntry
+        fields = '__all__'

--- a/sme_coad_apps/core/api/viewsets/divisao_viewset.py
+++ b/sme_coad_apps/core/api/viewsets/divisao_viewset.py
@@ -1,10 +1,12 @@
-from rest_framework import viewsets
 
-from ...models import Divisao
 from ..serializers.divisao_serializer import DivisaoSerializer
 
+from ...models import Divisao
+from ...viewsets_abstracts import ComHistoricoViewSet
 
-class DivisaoViewSet(viewsets.ModelViewSet):
+
+class DivisaoViewSet(ComHistoricoViewSet):
     lookup_field = 'uuid'
     queryset = Divisao.objects.all()
     serializer_class = DivisaoSerializer
+

--- a/sme_coad_apps/core/api/viewsets/nucleo_viewsets.py
+++ b/sme_coad_apps/core/api/viewsets/nucleo_viewsets.py
@@ -1,10 +1,9 @@
-from rest_framework import viewsets
-
 from ..serializers.nucleo_serializer import NucleoSerializer
 from ...models import Nucleo
+from ...viewsets_abstracts import ComHistoricoViewSet
 
 
-class NucleoViewSet(viewsets.ModelViewSet):
+class NucleoViewSet(ComHistoricoViewSet):
     lookup_field = 'uuid'
     queryset = Nucleo.objects.all()
     serializer_class = NucleoSerializer

--- a/sme_coad_apps/core/viewsets_abstracts.py
+++ b/sme_coad_apps/core/viewsets_abstracts.py
@@ -1,0 +1,17 @@
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from sme_coad_apps.core.api.serializers.historico_serializer import HistoricoSerializer
+
+
+class ComHistoricoViewSet(viewsets.ModelViewSet):
+
+    @action(detail=True)
+    def historico(self, request, uuid):
+        historico = self.get_object().historico.all()
+        serializer = HistoricoSerializer(historico, many=True)
+        return Response(serializer.data)
+
+    class Meta:
+        abstract = True


### PR DESCRIPTION
Esse PR:

- Cria um viewset abstrato que incorpora um endpoint para obter o histórico de alterações de um recurso

- Altera os viewsets de Divisão e Núcleo para exporem o endpoint de histórico.