### PR TITLE
feature/7403-atribuicao-cargos-divisao-api

### DIFF
--- a/sme_coad_apps/core/api/serializers/divisao_serializer.py
+++ b/sme_coad_apps/core/api/serializers/divisao_serializer.py
@@ -1,9 +1,13 @@
 from rest_framework import serializers
 
 from ...models import Divisao
+from ....users.api.serializers.usuario_serializer import UsuarioLookUpSerializer
 
 
 class DivisaoSerializer(serializers.ModelSerializer):
+    diretor = UsuarioLookUpSerializer()
+    suplente_diretor = UsuarioLookUpSerializer()
+
     class Meta:
         model = Divisao
         fields = '__all__'

--- a/sme_coad_apps/core/api/viewsets/divisao_viewset.py
+++ b/sme_coad_apps/core/api/viewsets/divisao_viewset.py
@@ -1,4 +1,4 @@
-from ..serializers.divisao_serializer import DivisaoSerializer
+from ..serializers.divisao_serializer import DivisaoSerializer, DivisaoSerializerCreator
 
 from ...models import Divisao
 from ...viewsets_abstracts import ComHistoricoViewSet
@@ -8,3 +8,11 @@ class DivisaoViewSet(ComHistoricoViewSet):
     lookup_field = 'uuid'
     queryset = Divisao.objects.all()
     serializer_class = DivisaoSerializer
+
+    def get_serializer_class(self):
+        if self.action == 'retrieve':
+            return DivisaoSerializer
+        elif self.action == 'list':
+            return DivisaoSerializer
+        else:
+            return DivisaoSerializerCreator

--- a/sme_coad_apps/core/tests/test_divisao_serializer.py
+++ b/sme_coad_apps/core/tests/test_divisao_serializer.py
@@ -1,18 +1,32 @@
 import pytest
 from model_mommy import mommy
 
-from ..api.serializers.divisao_serializer import DivisaoLookUpSerializer
+from ..api.serializers.divisao_serializer import DivisaoLookUpSerializer, DivisaoSerializer
 from ..models.divisao import Divisao
 
 pytestmark = pytest.mark.django_db
 
 
-def test_divisao_lookup_serializer():
-    divisao = mommy.make(Divisao, id=1, sigla='dv1', nome='teste')
+@pytest.fixture
+def divisao(fake_user):
+    return mommy.make(Divisao, id=1, sigla='dv1', nome='teste', diretor=fake_user, suplente_diretor=fake_user)
 
+
+def test_divisao_lookup_serializer(divisao):
     divisao_serializer = DivisaoLookUpSerializer(divisao)
 
     assert divisao_serializer.data is not None
     assert 'id' not in divisao_serializer.data
     assert divisao_serializer.data['sigla'] == 'dv1'
+
+
+def test_divisao_serializer(divisao):
+    divisao_serializer = DivisaoSerializer(divisao)
+
+    assert divisao_serializer.data is not None
+
+    assert divisao_serializer.data['sigla'] == 'dv1'
+    assert divisao_serializer['id']
     assert divisao_serializer['uuid']
+    assert divisao_serializer['diretor']
+    assert divisao_serializer['suplente_diretor']

--- a/sme_coad_apps/users/api/serializers/usuario_serializer.py
+++ b/sme_coad_apps/users/api/serializers/usuario_serializer.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 from ..validations.usuario_validations import (senhas_devem_ser_iguais,
                                                registro_funcional_deve_existir,
                                                senha_nao_pode_ser_nulo)
-from ....core.api.serializers.divisao_serializer import DivisaoSerializer
 
 user_model = get_user_model()
 


### PR DESCRIPTION
Esse PR:
 - Inclui no serializer de Divisão as informações de usuário para os campos diretor e suplente do diretor.