### PR TITLE
Feature/7405 atribuica cargos nucleos api

### DIFF
--- a/sme_coad_apps/core/admin.py
+++ b/sme_coad_apps/core/admin.py
@@ -3,11 +3,17 @@ from django.contrib import admin
 from .models import Divisao, Nucleo, Unidade, Coad, CoadAssessor, Servidor
 
 
+class NucleoInLine(admin.TabularInline):
+    model = Nucleo
+    extra = 1  # Quantidade de linhas que serão exibidas.
+
+
 @admin.register(Divisao)
 class DivisaoAdmin(admin.ModelAdmin):
     list_display = ('sigla', 'nome')
     ordering = ('sigla',)
     search_fields = ('sigla', 'nome')
+    inlines = [NucleoInLine]
 
 
 class ServidoresInLine(admin.TabularInline):

--- a/sme_coad_apps/core/api/serializers/nucleo_serializer.py
+++ b/sme_coad_apps/core/api/serializers/nucleo_serializer.py
@@ -21,3 +21,9 @@ class NucleoLookUpSerializer(serializers.ModelSerializer):
     class Meta:
         model = Nucleo
         fields = ('sigla', 'uuid', 'divisao')
+
+
+class NucleoCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Nucleo
+        fields = ('id', 'sigla', 'nome', 'chefe', 'suplente_chefe', 'divisao', 'uuid')

--- a/sme_coad_apps/core/api/serializers/nucleo_serializer.py
+++ b/sme_coad_apps/core/api/serializers/nucleo_serializer.py
@@ -2,12 +2,17 @@ from rest_framework import serializers
 
 from ..serializers.divisao_serializer import DivisaoLookUpSerializer
 from ...models import Nucleo
+from ....users.api.serializers.usuario_serializer import UsuarioLookUpSerializer
 
 
 class NucleoSerializer(serializers.ModelSerializer):
+    divisao = DivisaoLookUpSerializer()
+    chefe = UsuarioLookUpSerializer()
+    suplente_chefe = UsuarioLookUpSerializer()
+
     class Meta:
         model = Nucleo
-        fields = ('id', 'sigla', 'nome')
+        fields = ('id', 'sigla', 'nome', 'chefe', 'suplente_chefe', 'divisao', 'uuid')
 
 
 class NucleoLookUpSerializer(serializers.ModelSerializer):

--- a/sme_coad_apps/core/api/viewsets/divisao_viewset.py
+++ b/sme_coad_apps/core/api/viewsets/divisao_viewset.py
@@ -1,5 +1,8 @@
-from ..serializers.divisao_serializer import DivisaoSerializer, DivisaoSerializerCreator
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
+from ..serializers.divisao_serializer import DivisaoSerializer, DivisaoSerializerCreator
+from ..serializers.nucleo_serializer import NucleoSerializer
 from ...models import Divisao
 from ...viewsets_abstracts import ComHistoricoViewSet
 
@@ -16,3 +19,11 @@ class DivisaoViewSet(ComHistoricoViewSet):
             return DivisaoSerializer
         else:
             return DivisaoSerializerCreator
+
+    @action(detail=True)
+    def nucleos(self, request, uuid=None):
+        divisao = self.get_object()
+        nucleos = divisao.nucleo_set.all()
+
+        serializer = NucleoSerializer(nucleos, many=True)
+        return Response(serializer.data)

--- a/sme_coad_apps/core/api/viewsets/nucleo_viewsets.py
+++ b/sme_coad_apps/core/api/viewsets/nucleo_viewsets.py
@@ -1,7 +1,7 @@
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from ..serializers.nucleo_serializer import NucleoSerializer, NucleoLookUpSerializer
+from ..serializers.nucleo_serializer import NucleoSerializer, NucleoLookUpSerializer, NucleoCreateSerializer
 from ...models import Nucleo
 from ...viewsets_abstracts import ComHistoricoViewSet
 
@@ -10,6 +10,14 @@ class NucleoViewSet(ComHistoricoViewSet):
     lookup_field = 'uuid'
     queryset = Nucleo.objects.select_related('divisao').all()
     serializer_class = NucleoSerializer
+
+    def get_serializer_class(self):
+        if self.action == 'retrieve':
+            return NucleoSerializer
+        elif self.action == 'list':
+            return NucleoSerializer
+        else:
+            return NucleoCreateSerializer
 
     @action(detail=False)
     def lookup(self, _):

--- a/sme_coad_apps/core/tests/test_divisao_endpoints.py
+++ b/sme_coad_apps/core/tests/test_divisao_endpoints.py
@@ -12,3 +12,8 @@ def test_url_unauthorizade(client):
 def test_url_authorized(authencticated_client):
     response = authencticated_client.get('/divisoes/')
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_url_divisoes_nucleos(client):
+    response = client.get('/divisoes/uuid_da_divisao/nucleos/')
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/sme_coad_apps/core/tests/test_nucleo_serializer.py
+++ b/sme_coad_apps/core/tests/test_nucleo_serializer.py
@@ -1,21 +1,38 @@
 import pytest
 from model_mommy import mommy
 
-from ..api.serializers.nucleo_serializer import NucleoLookUpSerializer
+from ..api.serializers.nucleo_serializer import NucleoLookUpSerializer, NucleoSerializer
 from ..models.divisao import Divisao
 from ..models.nucleo import Nucleo
 
 pytestmark = pytest.mark.django_db
 
 
-def test_nucleo_lookup_serializer():
-    divisao = mommy.make(Divisao, id=1, sigla='dv1', nome='teste')
-    nucleo = mommy.make(Nucleo, id=1, sigla='nc1', nome='teste', divisao=divisao)
+@pytest.fixture
+def divisao(fake_user):
+    return mommy.make(Divisao, id=1, sigla='dv1', nome='teste', diretor=fake_user, suplente_diretor=fake_user)
 
+
+@pytest.fixture
+def nucleo(fake_user, divisao):
+    return mommy.make(Nucleo, id=1, sigla='nc1', nome='nucleo teste', chefe=fake_user, suplente_chefe=fake_user,
+                      divisao=divisao)
+
+
+def test_nucleo_lookup_serializer(divisao, nucleo):
     nucleo_serializer = NucleoLookUpSerializer(nucleo)
-
     assert nucleo_serializer.data is not None
     assert 'id' not in nucleo_serializer.data
     assert nucleo_serializer.data['sigla'] == 'nc1'
     assert nucleo_serializer.data['divisao'] == {'sigla': divisao.sigla, 'uuid': str(divisao.uuid)}
     assert nucleo_serializer.data['uuid']
+
+
+def test_nucleo_serializer(divisao, nucleo):
+    nucleo_serializer = NucleoSerializer(nucleo)
+    assert nucleo_serializer.data is not None
+    assert nucleo_serializer.data['sigla'] == 'nc1'
+    assert nucleo_serializer.data['divisao'] == {'sigla': divisao.sigla, 'uuid': str(divisao.uuid)}
+    assert nucleo_serializer.data['uuid']
+    assert nucleo_serializer.data['chefe']
+    assert nucleo_serializer.data['suplente_chefe']


### PR DESCRIPTION
Esse PR:
- Altera a API de núcleos para permitir a persistência e recuperação dos cargos de chefe e suplente de um núcleo
- Cria na API recurso para retornar a lista dos núcleos de uma divisão