### PR TITLE
 feature/7405-atribuicao-servidores-nucleos-api-iii

### DIFF
--- a/sme_coad_apps/core/services.py
+++ b/sme_coad_apps/core/services.py
@@ -17,4 +17,4 @@ def limpa_servidores_nucleo(nucleo):
 
 def update_servidores_nucleo(servidores, nucleo):
     limpa_servidores_nucleo(nucleo=nucleo)
-    Servidor.append_servidores(servidores=servidores)
+    Servidor.append_servidores(nucleo=nucleo, servidores=servidores)


### PR DESCRIPTION
Esse PR:
- Corrige um erro na gravação de servidores de um núcleo. A gravação não estava sendo efetivada.